### PR TITLE
feat: `stream.on` API

### DIFF
--- a/.changeset/serious-peas-tan.md
+++ b/.changeset/serious-peas-tan.md
@@ -1,0 +1,18 @@
+---
+"@llama-flow/core": patch
+---
+
+feat: `stream.on` API
+
+```ts
+workflow.handle([startEvent], () => {
+  const { sendEvent } = getContext();
+  sendEvent(messageEvent.with("Hello World"));
+});
+
+const { stream, sendEvent } = workflow.createContext();
+const unsubscribe = stream.on(messageEvent, (event) => {
+  expect(event.data).toBe("Hello World");
+});
+sendEvent(startEvent.with());
+```

--- a/packages/core/src/core/stream.ts
+++ b/packages/core/src/core/stream.ts
@@ -1,0 +1,66 @@
+import { type WorkflowEvent, type WorkflowEventData } from "./event";
+import type { Subscribable } from "./utils";
+
+export class WorkflowStream<Event extends WorkflowEvent<any>> {
+  #subscribable: Subscribable<[event: WorkflowEventData<any>], void>;
+  #stream: ReadableStream<Event>;
+
+  on<T extends Event>(
+    event: T,
+    handler: (event: ReturnType<T["with"]>) => void,
+  ): () => void {
+    return this.#subscribable.subscribe((ev) => {
+      if (event.include(ev)) {
+        handler(ev as ReturnType<T["with"]>);
+      }
+    });
+  }
+
+  constructor(
+    subscribable: Subscribable<[event: WorkflowEventData<any>], void>,
+    stream: ReadableStream<Event>,
+  ) {
+    this.#subscribable = subscribable;
+    this.#stream = stream;
+  }
+
+  get locked() {
+    return this.#stream.locked;
+  }
+
+  [Symbol.asyncIterator](): ReadableStreamAsyncIterator<Event> {
+    return this.#stream[Symbol.asyncIterator]();
+  }
+
+  cancel(reason?: any): Promise<void> {
+    return this.#stream.cancel(reason);
+  }
+
+  getReader(): ReadableStreamDefaultReader<Event> {
+    return this.#stream.getReader() as ReadableStreamDefaultReader<Event>;
+  }
+
+  pipeThrough<T>(
+    transform: ReadableWritablePair<T, Event>,
+    options?: StreamPipeOptions,
+  ): ReadableStream<T> {
+    return this.#stream.pipeThrough(transform, options) as ReadableStream<T>;
+  }
+
+  pipeTo(
+    destination: WritableStream<Event>,
+    options?: StreamPipeOptions,
+  ): Promise<void> {
+    return this.#stream.pipeTo(destination, options);
+  }
+
+  tee(): [ReadableStream<Event>, ReadableStream<Event>] {
+    return this.#stream.tee() as [ReadableStream<Event>, ReadableStream<Event>];
+  }
+
+  values(
+    options?: ReadableStreamIteratorOptions,
+  ): ReadableStreamAsyncIterator<Event> {
+    return this.#stream.values(options) as ReadableStreamAsyncIterator<Event>;
+  }
+}

--- a/packages/core/src/core/stream.ts
+++ b/packages/core/src/core/stream.ts
@@ -48,11 +48,11 @@ export class WorkflowStream<Event extends WorkflowEvent<any>> {
     return this.#stream.getReader();
   }
 
-  pipeThrough<T>(
+  pipeThrough<T = WorkflowEventData<any>>(
     transform: ReadableWritablePair<T, ReturnType<Event["with"]>>,
     options?: StreamPipeOptions,
   ): ReadableStream<T> {
-    return this.#stream.pipeThrough(transform, options) as ReadableStream<T>;
+    return this.#stream.pipeThrough(transform, options);
   }
 
   pipeTo(

--- a/packages/core/tests/core/listener.spec.ts
+++ b/packages/core/tests/core/listener.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test, vi } from "vitest";
+import { createWorkflow, getContext, workflowEvent } from "@llama-flow/core";
+
+describe("workflow listener api", () => {
+  test("can listen message event", () => {
+    const workflow = createWorkflow();
+    const startEvent = workflowEvent();
+    const messageEvent = workflowEvent<string>({});
+    workflow.handle([startEvent], () => {
+      const { sendEvent } = getContext();
+      sendEvent(messageEvent.with("Hello World"));
+    });
+
+    const { stream, sendEvent } = workflow.createContext();
+    const callback = vi.fn((event: ReturnType<typeof messageEvent.with>) => {
+      expect(event.data).toBe("Hello World");
+    });
+    const unsubscribe = stream.on(messageEvent, callback);
+    sendEvent(startEvent.with());
+    expect(callback).toHaveBeenCalledTimes(1);
+    unsubscribe();
+    sendEvent(startEvent.with());
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Related: https://github.com/run-llama/llama-flow/issues/88

Support `stream.on` API

```ts
workflow.handle([startEvent], () => {
  const { sendEvent } = getContext();
  sendEvent(messageEvent.with("Hello World"));
});

const { stream, sendEvent } = workflow.createContext();
const unsubscribe = stream.on(messageEvent, (event) => {
  expect(event.data).toBe("Hello World");
});
sendEvent(startEvent.with());
```