### PR TITLE
fix: build and export all middlewares to esm and cjs modules

### DIFF
--- a/.changeset/afraid-gifts-give.md
+++ b/.changeset/afraid-gifts-give.md
@@ -1,0 +1,5 @@
+---
+"@llama-flow/core": patch
+---
+
+fix: build and export all middlewares to esm and cjs modules

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,20 +57,60 @@
       "default": "./dist/observable.js"
     },
     "./middleware/state": {
-      "types": "./middleware/state.d.ts",
-      "default": "./middleware/state.js"
+      "import": {
+        "types": "./middleware/state.d.ts",
+        "default": "./middleware/state.js"
+      },
+      "require": {
+        "types": "./middleware/state.d.cts",
+        "default": "./middleware/state.cjs"
+      },
+      "default": {
+        "types": "./middleware/state.d.ts",
+        "default": "./middleware/state.js"
+      }
     },
     "./middleware/trace-events": {
-      "types": "./middleware/trace-events.d.ts",
-      "default": "./middleware/trace-events.js"
+      "import": {
+        "types": "./middleware/trace-events.d.ts",
+        "default": "./middleware/trace-events.js"
+      },
+      "require": {
+        "types": "./middleware/trace-events.d.cts",
+        "default": "./middleware/trace-events.cjs"
+      },
+      "default": {
+        "types": "./middleware/trace-events.d.ts",
+        "default": "./middleware/trace-events.js"
+      }
     },
     "./middleware/validation": {
-      "types": "./middleware/validation.d.ts",
-      "default": "./middleware/validation.js"
+      "import": {
+        "types": "./middleware/validation.d.ts",
+        "default": "./middleware/validation.js"
+      },
+      "require": {
+        "types": "./middleware/validation.d.cts",
+        "default": "./middleware/validation.cjs"
+      },
+      "default": {
+        "types": "./middleware/validation.d.ts",
+        "default": "./middleware/validation.js"
+      }
     },
     "./middleware/snapshot": {
-      "types": "./middleware/snapshot.d.ts",
-      "default": "./middleware/snapshot.js"
+      "import": {
+        "types": "./middleware/snapshot.d.ts",
+        "default": "./middleware/snapshot.js"
+      },
+      "require": {
+        "types": "./middleware/snapshot.d.cts",
+        "default": "./middleware/snapshot.cjs"
+      },
+      "default": {
+        "types": "./middleware/snapshot.d.ts",
+        "default": "./middleware/snapshot.js"
+      }
     },
     "./util/p-retry": {
       "types": "./util/p-retry.d.ts",

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -49,7 +49,7 @@ export default defineConfig([
     entry: ["src/middleware/*.ts"],
     outDir: "middleware",
     external: ["@llama-flow/core", "@llama-flow/core/async-context"],
-    format: ["esm"],
+    format: ["esm", "cjs"],
     tsconfig: "./tsconfig.build.json",
     dts: true,
     sourcemap: true,


### PR DESCRIPTION
## Description

All the middlewares were currently built and exported in ESM modules.

Therefore, any projects using CJS would cause context issues inside the package.

### Conditions

- [x] This PR resolves issue [#1978](https://github.com/run-llama/LlamaIndexTS/issues/1978)
- [x] This PR would satisfy the modified test case in #110 